### PR TITLE
inherit from fieldcell and make nicer appearance in a list of cells

### DIFF
--- a/Resources/GenericPasswordCell.xib
+++ b/Resources/GenericPasswordCell.xib
@@ -23,12 +23,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="198"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="253" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Create password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Zy9-qp-gBx">
-                                <rect key="frame" x="22" y="12" width="329" height="17"/>
+                                <rect key="frame" x="16" y="12" width="329" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lnm-KM-o1x">
-                                <rect key="frame" x="361" y="10" width="22" height="22"/>
+                                <rect key="frame" x="355" y="10" width="22" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="lnm-KM-o1x" secondAttribute="height" id="cMs-S1-GBE"/>
                                     <constraint firstAttribute="width" constant="22" id="gaV-V2-qNo"/>
@@ -36,7 +36,7 @@
                                 <state key="normal" image="visibility.png"/>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8m2-Ek-2uQ" customClass="DefaultPasswordStrengthView" customModule="GenericPasswordRow" customModuleProvider="target">
-                                <rect key="frame" x="10" y="35" width="373" height="5"/>
+                                <rect key="frame" x="16" y="35" width="361" height="5"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="5" id="8df-ch-q1A"/>
@@ -52,16 +52,16 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="lnm-KM-o1x" firstAttribute="leading" secondItem="Zy9-qp-gBx" secondAttribute="trailing" constant="10" id="5nR-b8-58B"/>
-                            <constraint firstAttribute="trailing" secondItem="lnm-KM-o1x" secondAttribute="trailing" constant="10" id="AUP-Wp-2yc"/>
+                            <constraint firstItem="lnm-KM-o1x" firstAttribute="trailing" secondItem="8m2-Ek-2uQ" secondAttribute="trailing" id="83O-Mt-PJ2"/>
+                            <constraint firstAttribute="trailing" secondItem="lnm-KM-o1x" secondAttribute="trailing" constant="16" id="AUP-Wp-2yc"/>
                             <constraint firstItem="wOo-IE-4vB" firstAttribute="centerX" secondItem="Tyh-Vt-DFb" secondAttribute="centerX" id="EAz-sa-xiM"/>
                             <constraint firstItem="lnm-KM-o1x" firstAttribute="centerY" secondItem="Zy9-qp-gBx" secondAttribute="centerY" id="Zgx-dV-oPo"/>
                             <constraint firstItem="8m2-Ek-2uQ" firstAttribute="top" secondItem="Zy9-qp-gBx" secondAttribute="bottom" constant="6" id="fom-uj-88T"/>
-                            <constraint firstItem="Zy9-qp-gBx" firstAttribute="leading" secondItem="Tyh-Vt-DFb" secondAttribute="leading" constant="22" id="lRa-nV-O9c"/>
-                            <constraint firstItem="8m2-Ek-2uQ" firstAttribute="leading" secondItem="Tyh-Vt-DFb" secondAttribute="leading" constant="10" id="r3P-Tl-wcE"/>
-                            <constraint firstAttribute="trailing" secondItem="8m2-Ek-2uQ" secondAttribute="trailing" constant="10" id="t2D-BY-nFh"/>
+                            <constraint firstItem="Zy9-qp-gBx" firstAttribute="leading" secondItem="Tyh-Vt-DFb" secondAttribute="leading" constant="16" id="lRa-nV-O9c"/>
                             <constraint firstItem="Zy9-qp-gBx" firstAttribute="top" secondItem="Tyh-Vt-DFb" secondAttribute="top" constant="12" id="uBJ-pR-RE7"/>
                             <constraint firstItem="8m2-Ek-2uQ" firstAttribute="leading" secondItem="Zy9-qp-gBx" secondAttribute="leading" id="uQo-kZ-xY5"/>
                             <constraint firstAttribute="bottom" secondItem="wOo-IE-4vB" secondAttribute="bottom" constant="3" id="v13-h7-ubq"/>
+                            <constraint firstItem="8m2-Ek-2uQ" firstAttribute="leading" secondItem="Zy9-qp-gBx" secondAttribute="leading" id="vho-ft-Nyl"/>
                             <constraint firstItem="wOo-IE-4vB" firstAttribute="top" secondItem="8m2-Ek-2uQ" secondAttribute="bottom" constant="3" id="wcD-wv-hwb"/>
                         </constraints>
                         <variation key="default">
@@ -80,8 +80,10 @@
             </tableViewCellContentView>
             <connections>
                 <outlet property="hintLabel" destination="wOo-IE-4vB" id="T1I-It-Pxo"/>
+                <outlet property="leading" destination="lRa-nV-O9c" id="bL6-Nc-e7S"/>
                 <outlet property="passwordStrengthView" destination="8m2-Ek-2uQ" id="QiY-2S-FbF"/>
                 <outlet property="textField" destination="Zy9-qp-gBx" id="okX-a5-G3H"/>
+                <outlet property="trailing" destination="AUP-Wp-2yc" id="EyW-oa-GGd"/>
                 <outlet property="visibilityButton" destination="lnm-KM-o1x" id="Sex-mW-T4T"/>
             </connections>
             <point key="canvasLocation" x="-425.5" y="405.5"/>

--- a/Resources/GenericPasswordCell.xib
+++ b/Resources/GenericPasswordCell.xib
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment version="2048" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -12,14 +16,14 @@
             <rect key="frame" x="0.0" y="0.0" width="393" height="199"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="laY-Xe-HBQ" id="m16-zs-DcU">
-                <rect key="frame" x="0.0" y="0.0" width="393" height="198"/>
+                <rect key="frame" x="0.0" y="0.0" width="393" height="198.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tyh-Vt-DFb">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="198"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="253" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Create password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Zy9-qp-gBx">
-                                <rect key="frame" x="10" y="12" width="341" height="17"/>
+                                <rect key="frame" x="22" y="12" width="329" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
@@ -33,7 +37,7 @@
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8m2-Ek-2uQ" customClass="DefaultPasswordStrengthView" customModule="GenericPasswordRow" customModuleProvider="target">
                                 <rect key="frame" x="10" y="35" width="373" height="5"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="5" id="8df-ch-q1A"/>
                                 </constraints>
@@ -41,24 +45,30 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="afsda" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wOo-IE-4vB">
                                 <rect key="frame" x="183" y="43" width="27" height="152"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="lnm-KM-o1x" firstAttribute="leading" secondItem="Zy9-qp-gBx" secondAttribute="trailing" constant="10" id="5nR-b8-58B"/>
                             <constraint firstAttribute="trailing" secondItem="lnm-KM-o1x" secondAttribute="trailing" constant="10" id="AUP-Wp-2yc"/>
                             <constraint firstItem="wOo-IE-4vB" firstAttribute="centerX" secondItem="Tyh-Vt-DFb" secondAttribute="centerX" id="EAz-sa-xiM"/>
                             <constraint firstItem="lnm-KM-o1x" firstAttribute="centerY" secondItem="Zy9-qp-gBx" secondAttribute="centerY" id="Zgx-dV-oPo"/>
                             <constraint firstItem="8m2-Ek-2uQ" firstAttribute="top" secondItem="Zy9-qp-gBx" secondAttribute="bottom" constant="6" id="fom-uj-88T"/>
-                            <constraint firstItem="Zy9-qp-gBx" firstAttribute="leading" secondItem="Tyh-Vt-DFb" secondAttribute="leading" constant="10" id="lRa-nV-O9c"/>
+                            <constraint firstItem="Zy9-qp-gBx" firstAttribute="leading" secondItem="Tyh-Vt-DFb" secondAttribute="leading" constant="22" id="lRa-nV-O9c"/>
+                            <constraint firstItem="8m2-Ek-2uQ" firstAttribute="leading" secondItem="Tyh-Vt-DFb" secondAttribute="leading" constant="10" id="r3P-Tl-wcE"/>
                             <constraint firstAttribute="trailing" secondItem="8m2-Ek-2uQ" secondAttribute="trailing" constant="10" id="t2D-BY-nFh"/>
                             <constraint firstItem="Zy9-qp-gBx" firstAttribute="top" secondItem="Tyh-Vt-DFb" secondAttribute="top" constant="12" id="uBJ-pR-RE7"/>
                             <constraint firstItem="8m2-Ek-2uQ" firstAttribute="leading" secondItem="Zy9-qp-gBx" secondAttribute="leading" id="uQo-kZ-xY5"/>
                             <constraint firstAttribute="bottom" secondItem="wOo-IE-4vB" secondAttribute="bottom" constant="3" id="v13-h7-ubq"/>
                             <constraint firstItem="wOo-IE-4vB" firstAttribute="top" secondItem="8m2-Ek-2uQ" secondAttribute="bottom" constant="3" id="wcD-wv-hwb"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="uQo-kZ-xY5"/>
+                            </mask>
+                        </variation>
                     </view>
                 </subviews>
                 <constraints>

--- a/Sources/GenericPasswordCell.swift
+++ b/Sources/GenericPasswordCell.swift
@@ -9,9 +9,8 @@
 import Foundation
 import Eureka
 
-open class GenericPasswordCell: Cell<String>, CellType {
+open class GenericPasswordCell: _FieldCell<String>, CellType {
 
-    @IBOutlet public weak var textField: UITextField!
     @IBOutlet weak var visibilityButton: UIButton?
     @IBOutlet weak var passwordStrengthView: PasswordStrengthView?
     @IBOutlet public weak var hintLabel: UILabel?
@@ -81,7 +80,7 @@ open class GenericPasswordCell: Cell<String>, CellType {
         visibilityButton?.setImage(textField.isSecureTextEntry ? visibilityImage.on : visibilityImage.off, for: .normal)
     }
 
-    open func textFieldDidChange(_ textField: UITextField) {
+    open override func textFieldDidChange(_ textField: UITextField) {
         genericPasswordRow.value = textField.text
         updatePasswordStrengthIfNeeded()
 

--- a/Sources/GenericPasswordCell.swift
+++ b/Sources/GenericPasswordCell.swift
@@ -15,6 +15,9 @@ open class GenericPasswordCell: _FieldCell<String>, CellType {
     @IBOutlet weak var passwordStrengthView: PasswordStrengthView?
     @IBOutlet public weak var hintLabel: UILabel?
 
+    @IBOutlet public weak var leading: NSLayoutConstraint!
+    @IBOutlet public weak var trailing: NSLayoutConstraint!
+
     var genericPasswordRow: _GenericPasswordRow! {
         return row as? _GenericPasswordRow
     }

--- a/Sources/GenericPasswordRow.swift
+++ b/Sources/GenericPasswordRow.swift
@@ -9,7 +9,10 @@
 import Foundation
 import Eureka
 
-open class _GenericPasswordRow: Row<GenericPasswordCell> {
+open class _GenericPasswordRow: Row<GenericPasswordCell>, KeyboardReturnHandler {
+
+    /// Configuration for the keyboardReturnType of this row
+    open var keyboardReturnType: KeyboardReturnTypeConfiguration?
 
     open var passwordValidator: PasswordValidator = DefaultPasswordValidator()
     open var placeholder: String? = "Password"


### PR DESCRIPTION
Hello! Thank you for this library, it is the only custom eureka cell I use and is a great one.

I made this pull request to improve the row's behaviour in the context of a multi-row form. Inheriting from _FieldCell and KeyboardReturnHandler means the keyboard will have Next and Return on the keyboard with the expected "Eureka Standard" actions. It also gives the same TextFieldDelegate methods as all the other FieldCells so that the behaviour around text entry should be the same.

I also modified the constraints of the cell:
-changed the TextField's leading edge to 22 (from 10, aligns with other Eureka Text rows)
-changed the password strength indicators leading edge to 10 (instead of match the TextField).

Thanks again,
Konrad